### PR TITLE
Modifications to make this work inside larger merge program

### DIFF
--- a/App.sh
+++ b/App.sh
@@ -4,7 +4,7 @@ PYTHON=/opt/common/CentOS_6/python/python-2.7.8/bin/python2.7
 REPO=/ifs/res/socci/Work/CMO/CMOMerge/bic-mskcc
 
 usage() {
-    echo "CMOMerge/App.sh -p projectTag -b baseProject"
+    echo "CMOMerge/App.sh -p projectTag -b baseProject -r repository -s python_path"
     echo "    projectTag = string to grep for to find projects to merge"
     echo "    baseProject = full project ID for the base project of merge"
     echo
@@ -22,7 +22,7 @@ TUMORARG=""
 MERGEARG=""
 FORCEARG=""
 rm -f merge_exclude
-while getopts ":b:p:l:t:n:e:hf" opt; do
+while getopts ":b:p:l:t:n:r:s:e:hf" opt; do
     case $opt in
         b)
             BASETAG=$OPTARG
@@ -38,6 +38,12 @@ while getopts ":b:p:l:t:n:e:hf" opt; do
             ;;
         n)
             MERGEARG="-n "${OPTARG/-/_}
+            ;;
+        r)
+            REPO=$OPTARG
+            ;;
+        s)
+            PYTHON=$OPTARG
             ;;
         e)
             echo "/"$OPTARG"$" >>merge_exclude

--- a/MergePortal/__main__.py
+++ b/MergePortal/__main__.py
@@ -148,9 +148,7 @@ print "mergeBatches =", mergeBatches
 print "projectList =", projectList
 print "projectTag =", projectTag
 
-#REPO_ROOT="_merge"
-REPO_ROOT="bic-mskcc"
-outPath=Path("/".join([REPO_ROOT,tumorType,institutionName,labName,projectNumber]))
+outPath=Path("/".join([tumorType,institutionName,labName,projectNumber]))
 caseListDir=Path("case_lists")
 
 

--- a/MergePortal/__main__.py
+++ b/MergePortal/__main__.py
@@ -158,7 +158,7 @@ if outPath.exists():
 		print >>sys.stderr, "Will not overwrite\n"
 		sys.exit()
 	else:
-		print >>sys.stderr, "\n Overwriting", outPath
+		print "\n Overwriting", outPath
 		import shutil
 		shutil.rmtree(str(outPath))
 


### PR DESCRIPTION
- Repository checkout location and Python executable are parameters
- Root of repository removed
- Only write to stderr on error
